### PR TITLE
Automatically select first connected screen

### DIFF
--- a/xscreenrotater
+++ b/xscreenrotater
@@ -47,9 +47,9 @@ def get_args():
     parser.add_argument(
         "-d",
         "--display",
-        help="Which X11 display should be rotated.",
+        help="Which X11 display should be rotated, tries to defeault to the first screen it finds.",
         metavar="DISPLAY",
-        required=True,
+        default=get_screen_name(),
     )
 
     # Add -l/--left_shift argument to set the left shift.

--- a/xscreenrotater
+++ b/xscreenrotater
@@ -3,13 +3,34 @@ import os
 import math
 import time
 import argparse
+import subprocess
+import re
+
+def get_screen_name():
+    try:
+        output = subprocess.check_output(['xrandr'], universal_newlines=True)
+
+        pattern = re.compile(r'^\S+ connected.*$')
+        connected_lines = [line.strip() for line in output.split('\n') if pattern.match(line)]
+
+        # Extract the screen name from the first connected line
+        if connected_lines:
+            screen_name = connected_lines[0].split()[0]
+            return screen_name
+        else:
+            return None
+
+    except subprocess.CalledProcessError as e:
+        print(f"Error: {e}")
+        return None
+
 
 parser=argparse.ArgumentParser(
     prog="Xscreenrotater",
     description="This script will rotate your X11 screen until you tell it to stop, " +\
         "this is basically malware, please don't come to me if you break your PC"
 )
-parser.add_argument("-d", "--display", help="Which X11 display should be rotated", metavar="DISPLAY", required=True)
+parser.add_argument("-d", "--display", help="Which X11 display should be rotated, tries to default to the first connectd screen", metavar="DISPLAY", type=str, default=get_screen_name())
 parser.add_argument("-l", "--left_shift", help="Amount to horizontally shift the display, defaults to 0", type=float, 
     default=0, metavar="X")
 parser.add_argument("-u", "--up_shift", help="Amount to vertically shift the display, defaults to 0", type=float, 


### PR DESCRIPTION
I removed the required=yes and added a subprocess that runs xrandr and, with a re, extracts the first connected monitor output.
This may need some testing, I tried it on two physical and one virtual machine and it worked, but as there may be many configurations it may not work in some cases. I have not found a case where it fails, but maybe if the screen name has a space in it, it might break.