### PR TITLE
add type float to argument --degrees

### DIFF
--- a/xscreenrotater
+++ b/xscreenrotater
@@ -69,6 +69,7 @@ def get_args():
         help="How many degrees should the script start at, defaults to 0.",
         metavar="DEGREES",
         default=0,
+        type=float,
     )
 
     # Add -t/--times argument for the times the screen rotates.


### PR DESCRIPTION
when I run this script it prints an error

```pytb
Traceback (most recent call last):
  File "xscreenrotater", line 168, in <module>
    main()
  File "xscreenrotater", line 159, in main
    while count < times:
          ^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'str' and 'float'
```

argument degrees have type string
